### PR TITLE
[ISSUE-012] 약속 관리 화면의 약속 아이템 파티장/파티원 뱃지 위치 수정

### DIFF
--- a/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
+++ b/presentation/src/main/java/com/yapp/growth/presentation/ui/main/manage/ManageScreen.kt
@@ -329,14 +329,15 @@ fun ManagePlansItem(
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
+                    ManageLeaderBadge(
+                        modifier = Modifier.align(Alignment.CenterVertically),
+                        isLeader = plan.isLeader
+                    )
+
                     Text(
                         text = plan.title,
                         style = PlanzTypography.subtitle1,
                         color = Gray900
-                    )
-                    ManageLeaderBadge(
-                        modifier = Modifier.align(Alignment.CenterVertically),
-                        isLeader = plan.isLeader
                     )
                 }
 


### PR DESCRIPTION
## ISSUE
- resolved #12 

<br>

## 작업 내용
- 약속 관리 화면의 약속 아이템 -> 파티장/파티원 뱃지 위치 수정(디자인 변경사항 반영)


<br>

## 실행 화면

| Screen Shot | Screen Shot |
| ----------- | ----------- |
| <img width="512" alt="image" src="https://user-images.githubusercontent.com/42907876/228319059-7f88f59a-ba57-4c96-ad56-c2806dc1d8d0.png">  |             |


<br>

## Check List
- [x] PR 제목은 `[ISSUE-{N}] PR 제목`으로 작성
- [ ] CI/CD 통과 여부
- [ ] 1명 이상의 Approve 확인 후 Merge
- [x] 관련 이슈 연결
